### PR TITLE
Support for SSL and usage of connection factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,9 @@
   },
   "require-dev": {
     "laravel/pint": "^1.18",
+    "mockery/mockery": "^1.6",
     "pestphp/pest": "^1.23",
+    "pestphp/pest-plugin-laravel": "^1.4",
     "phpunit/phpunit": "^9.0",
     "symfony/var-dumper": "^6.4"
   },

--- a/config/simple-mq.php
+++ b/config/simple-mq.php
@@ -28,6 +28,7 @@ return [
     'connections' => [
 
         'default' => [
+            'io_type' => 'stream',
             'host' => env('SIMPLE_MQ_HOST', 'localhost'),
             'port' => env('SIMPLE_MQ_PORT', 5672),
             'username' => env('SIMPLE_MQ_USERNAME', 'guest'),
@@ -43,7 +44,18 @@ return [
             'keepalive' => false,
             'heartbeat' => false,
             'channel_rpc_timeout' => 0,
-            'ssl_protocol' => null,
+            'is_secure' => null,
+            'is_lazy' => null,
+            'ssl_ca_cert' => null,
+            'ssl_ca_path' => null,
+            'ssl_cert' => null,
+            'ssl_key' => null,
+            'ssl_verify' => null,
+            'ssl_verify_name' => null,
+            'ssl_pass_phrase' => null,
+            'ssl_ciphers' => null,
+            'ssl_security_level' => null,
+            'ssl_crypto_method' => null,
         ],
     ],
 

--- a/src/ConsumeMQ.php
+++ b/src/ConsumeMQ.php
@@ -6,7 +6,7 @@ use Exception;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Config;
 use PhpAmqpLib\Channel\AMQPChannel;
-use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Connection\AbstractConnection;
 use Usmonaliyev\SimpleRabbit\MQ\ConnectionManager;
 
 class ConsumeMQ
@@ -21,7 +21,7 @@ class ConsumeMQ
      */
     private ?string $queue = null;
 
-    private AMQPStreamConnection $amqpConnection;
+    private AbstractConnection $amqpConnection;
 
     private AMQPChannel $channel;
 

--- a/src/MQ/Connection.php
+++ b/src/MQ/Connection.php
@@ -43,7 +43,7 @@ class Connection
         $connectionConfig->setVhost($config['vhost']);
         $connectionConfig->setInsist($config['insist']);
         $connectionConfig->setLoginMethod($config['login_method']);
-        $connectionConfig->setLoginResponse($config['login_response']);
+        $connectionConfig->setLoginResponse($config['login_response'] ?? '');
         $connectionConfig->setLocale($config['locale']);
         $connectionConfig->setConnectionTimeout($config['connection_timeout']);
         $connectionConfig->setReadTimeout($config['read_write_timeout']);
@@ -51,8 +51,8 @@ class Connection
         $connectionConfig->setKeepalive($config['keepalive']);
         $connectionConfig->setHeartbeat($config['heartbeat']);
         $connectionConfig->setChannelRPCTimeout($config['channel_rpc_timeout']);
-        $connectionConfig->setIsSecure($config['is_secure']);
-        $connectionConfig->setIsLazy($config['is_lazy']);
+        $connectionConfig->setIsSecure($config['is_secure'] ?? false);
+        $connectionConfig->setIsLazy($config['is_lazy'] ?? false);
         $connectionConfig->setSslCaCert($config['ssl_ca_cert']);
         $connectionConfig->setSslCaPath($config['ssl_ca_path']);
         $connectionConfig->setSslCert($config['ssl_cert']);

--- a/src/MQ/Connection.php
+++ b/src/MQ/Connection.php
@@ -5,7 +5,9 @@ namespace Usmonaliyev\SimpleRabbit\MQ;
 use Exception;
 use Illuminate\Support\Facades\Config;
 use PhpAmqpLib\Channel\AMQPChannel;
-use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Connection\AbstractConnection;
+use PhpAmqpLib\Connection\AMQPConnectionConfig;
+use PhpAmqpLib\Connection\AMQPConnectionFactory;
 use Usmonaliyev\SimpleRabbit\Exceptions\ConnectionNotFoundException;
 
 class Connection
@@ -15,7 +17,7 @@ class Connection
      */
     private $name;
 
-    private AMQPStreamConnection $connection;
+    private AbstractConnection $connection;
 
     /**
      * Initializes the RabbitMQ connection with the provided configuration.
@@ -32,24 +34,37 @@ class Connection
             throw new ConnectionNotFoundException($name);
         }
 
-        $this->connection = new AMQPStreamConnection(
-            $config['host'],
-            $config['port'],
-            $config['username'],
-            $config['password'],
-            $config['vhost'],
-            $config['insist'],
-            $config['login_method'],
-            $config['login_response'],
-            $config['locale'],
-            $config['connection_timeout'],
-            $config['read_write_timeout'],
-            $config['context'],
-            $config['keepalive'],
-            $config['heartbeat'],
-            $config['channel_rpc_timeout'],
-            $config['ssl_protocol']
-        );
+        $connectionConfig = new AMQPConnectionConfig();
+        $connectionConfig->setIoType($config['io_type']);
+        $connectionConfig->setHost($config['host']);
+        $connectionConfig->setPort($config['port']);
+        $connectionConfig->setUser($config['username']);
+        $connectionConfig->setPassword($config['password']);
+        $connectionConfig->setVhost($config['vhost']);
+        $connectionConfig->setInsist($config['insist']);
+        $connectionConfig->setLoginMethod($config['login_method']);
+        $connectionConfig->setLoginResponse($config['login_response']);
+        $connectionConfig->setLocale($config['locale']);
+        $connectionConfig->setConnectionTimeout($config['connection_timeout']);
+        $connectionConfig->setReadTimeout($config['read_write_timeout']);
+        $connectionConfig->setStreamContext($config['context']);
+        $connectionConfig->setKeepalive($config['keepalive']);
+        $connectionConfig->setHeartbeat($config['heartbeat']);
+        $connectionConfig->setChannelRPCTimeout($config['channel_rpc_timeout']);
+        $connectionConfig->setIsSecure($config['is_secure']);
+        $connectionConfig->setIsLazy($config['is_lazy']);
+        $connectionConfig->setSslCaCert($config['ssl_ca_cert']);
+        $connectionConfig->setSslCaPath($config['ssl_ca_path']);
+        $connectionConfig->setSslCert($config['ssl_cert']);
+        $connectionConfig->setSslKey($config['ssl_key']);
+        $connectionConfig->setSslVerify($config['ssl_verify']);
+        $connectionConfig->setSslVerifyName($config['ssl_verify_name']);
+        $connectionConfig->setSslPassPhrase($config['ssl_pass_phrase']);
+        $connectionConfig->setSslCiphers($config['ssl_ciphers']);
+        $connectionConfig->setSslSecurityLevel($config['ssl_security_level']);
+        $connectionConfig->setSslCryptoMethod($config['ssl_crypto_method']);
+
+        $this->connection = AMQPConnectionFactory::create($connectionConfig);
     }
 
     /**
@@ -71,11 +86,11 @@ class Connection
     }
 
     /**
-     * Returns the active AMQPStreamConnection connection.
+     * Returns the active AbstractConnection connection.
      *
      * @throws Exception
      */
-    public function getAMQPConnection(): AMQPStreamConnection
+    public function getAMQPConnection(): AbstractConnection
     {
         return $this->connection;
     }

--- a/src/MQ/Definition.php
+++ b/src/MQ/Definition.php
@@ -4,12 +4,12 @@ namespace Usmonaliyev\SimpleRabbit\MQ;
 
 use Exception;
 use PhpAmqpLib\Channel\AMQPChannel;
-use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Connection\AbstractConnection;
 use PhpAmqpLib\Wire\AMQPTable;
 
 class Definition
 {
-    private AMQPStreamConnection $connection;
+    private AbstractConnection $connection;
 
     private AMQPChannel $channel;
 
@@ -43,7 +43,7 @@ class Definition
      */
     private array $arguments = [];
 
-    public function __construct(AMQPStreamConnection $connection)
+    public function __construct(AbstractConnection $connection)
     {
         $this->connection = $connection;
 

--- a/tests/Feature/SimpleMQTest.php
+++ b/tests/Feature/SimpleMQTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Config;
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Connection\AMQPConnectionFactory;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
+use Usmonaliyev\SimpleRabbit\MQ\Connection;
+use Usmonaliyev\SimpleRabbit\MQ\ConnectionManager;
+use Usmonaliyev\SimpleRabbit\MQ\MessageBuilder;
+use Usmonaliyev\SimpleRabbit\SimpleMQ;
+use function PHPUnit\Framework\assertInstanceOf;
+
+
+// This is a helper function to create a fresh test environment for each test
+function setupTest(array $configs = []) {
+    // Reset Mockery
+    Mockery::close();
+    $defaultConfigs = require('config/simple-mq.php');
+    $configs = array_merge($defaultConfigs, $configs);
+
+    Config::shouldReceive('get')
+        ->andReturnUsing(function ($key) use ($configs) {
+            return data_get($configs, substr($key, 10));
+        })
+        ->byDefault();
+
+    App::shouldReceive('make')->with(ConnectionManager::class)->andReturnUsing(fn() => new ConnectionManager());
+
+    $test = new stdClass();
+    $test->channel = Mockery::mock(AMQPChannel::class);
+    $test->channel->shouldReceive('basic_publish')->withAnyArgs()->andReturn();
+
+    $test->connection = Mockery::mock(AMQPStreamConnection::class);
+    $test->connection->shouldReceive('channel')->andReturn($test->channel);
+    $test->connection->shouldReceive('close')->andReturn();
+
+    $test->connectionFactory = Mockery::mock('alias:'. AMQPConnectionFactory::class)
+        ->shouldReceive('create')
+        ->andReturn($test->connection);
+
+    $test->simpleMq = new SimpleMQ();
+    return $test;
+}
+
+beforeEach(function () {
+    // This is intentionally left empty as we'll use the setupTest function in each test
+});
+
+afterEach(function () {
+    Mockery::close();
+});
+
+test('connection method with name parameter returns the specified connection', function () {
+    $test = setupTest();
+    /** @var Connection $connection */
+    $connection = $test->simpleMq->connection('default');
+    assertInstanceOf(Connection::class, $connection);;
+});
+
+test('can send message to queue', function () {
+    $test = setupTest();
+    /** @var MessageBuilder $queue */
+    $queue = $test->simpleMq->queue('default');
+    $queue->setBody(['name' => 'First Foo'])
+        ->handler('create-foo')
+        ->publish();
+
+    $test->channel->shouldHaveReceived('basic_publish')->withArgs([new \Mockery\Matcher\Any(), '', 'default'])->once();
+});
+
+test('can send message to exchange', function () {
+    $test = setupTest();
+    /** @var MessageBuilder $exchange */
+    $exchange = $test->simpleMq->exchange('default');
+    $exchange->setBody(['name' => 'First Foo'])
+        ->setRoutingKey('foo.create')
+        ->handler('create-foo')
+        ->publish();
+
+    $test->channel->shouldHaveReceived('basic_publish')->withArgs([new \Mockery\Matcher\Any(), 'default', 'foo.create'])->once();
+});


### PR DESCRIPTION
Use AMQPConnectionFactory to create the connection to RabbitMq, this way we can connect with Sockets

Support for SSL parameters to connect to protected instances